### PR TITLE
Version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 [![Build Status](https://travis-ci.org/m4rcu5nl/ansible-role-zerotier.svg?branch=master)](https://travis-ci.org/m4rcu5nl/ansible-role-zerotier) [![GitHub issues](https://img.shields.io/github/issues/m4rcu5nl/ansible-role-zerotier.svg)](https://github.com/m4rcu5nl/ansible-role-zerotier/issues)
 
-Zerotier
+ZeroTier
 =========
 
-This Ansible role installs the zerotier-one package, adds and authorizes new members to (existing) Zerotier network and tells the new members to join the network.
+This Ansible role installs the `zerotier-one` package, adds and authorizes new members to (existing) ZeroTier networks, and tells the new member to join the network.
 
 Requirements
 ------------
 
-This roles requires an access token for the Zerotier API. This enables the role to add new members to a private network and authorizes them. Also, the role needs the network ID of the Zerotier network the new members should join.
+This role has an optional access token variable to authorize the member using the ZeroTier API. The role also takes the ID of the ZeroTier network to automatically join the new member.
 
 Role Variables
 --------------
 
 ### zerotier_api_url
-The url where the Zerotier API lives. Must use https protocol.    
+The url where the Zerotier API lives. Must use HTTPS protocol.
 Default: https://my.zerotier.com
 
 ### zerotier_accesstoken
-The access token needed to authorize with the Zerotier API. You can generate one in your account settings on my.zerotier.com.
+The access token needed to authorize with the ZeroTier API. You can generate one in your account settings at https://my.zerotier.com/. If this is left out then the newly joined member will not be automatically authorized.
 
-### zerotier_network_id (required)
-The 16 character network ID of the network the new members should join.
+### zerotier_network_id
+The 16 character network ID of the network the new members should join. The node will not join any network if omitted.
+
+### zerotier_register_short_hostname
+Used to register the short hostname (without the FQDN) on the network instead of the long one.
+Default: `false`
+
+### zerotier_member_ip_assignments
+A list of IP addresses to assign this member. The member will be automatically assigned an address on the network if left out.
 
 Example Playbook
 ----------------
@@ -31,6 +38,8 @@ Example Playbook
       vars:
          zerotier_network_id: 1234567890qwerty
          zerotier_accesstoken: "{{ vault_zerotier_accesstoken }}"
+         zerotier_member_ip_assignments:
+           - 192.168.195.1
       roles:
          - { role: m4rcu5nl.zerotier }
 ```

--- a/README.md
+++ b/README.md
@@ -38,8 +38,17 @@ Example Playbook
       vars:
          zerotier_network_id: 1234567890qwerty
          zerotier_accesstoken: "{{ vault_zerotier_accesstoken }}"
-         zerotier_member_ip_assignments:
-           - 192.168.195.1
+         zerotier_register_short_hostname: true
+
       roles:
          - { role: m4rcu5nl.zerotier }
+```
+
+Example Inventory
+----------------
+
+```INI
+    [servers]
+    web1.example.com zerotier_member_ip_assignments='["192.168.195.1", "192.168.195.2", "192.168.195.3"]'
+    db1.example.com zerotier_member_ip_assignments='["192.168.195.10"]'
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Default: `false`
 ### zerotier_member_ip_assignments
 A list of IP addresses to assign this member. The member will be automatically assigned an address on the network if left out.
 
+### zerotier_member_description
+Optional desription for a member.
+
 Example Playbook
 ----------------
 
@@ -49,6 +52,24 @@ Example Inventory
 
 ```INI
     [servers]
-    web1.example.com zerotier_member_ip_assignments='["192.168.195.1", "192.168.195.2", "192.168.195.3"]'
+    web1.example.com zerotier_member_ip_assignments='["192.168.195.1", "192.168.195.2"]'
+    web2.example.com zerotier_member_ip_assignments='["192.168.195.3", "192.168.195.4"'
     db1.example.com zerotier_member_ip_assignments='["192.168.195.10"]'
+    db2.example.com zerotier_member_ip_assignments='["192.168.195.11"]'
+    db3.example.com zerotier_member_ip_assignments='["192.168.195.12"]'
+
+    [webservers]
+    web1.example.com
+    web2.example.com
+
+    [dbservers]
+    db1.example.com
+    db2.example.com
+    db3.example.com
+
+    [webservers:vars]
+    zerotier_member_description='<AppName> webserver'
+
+    [dbservers:vars]
+    zerotier_member_description='<AppName> db cluster node'
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # defaults file for ansible-role-zerotier
 zerotier_api_url: https://my.zerotier.com
+zerotier_apt_state: present
+zerotier_register_short_hostname: false
+zerotier_authorize_member: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: BSD
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.4
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -38,7 +38,7 @@ galaxy_info:
     - 7
   - name: Debian
     versions:
-    - all
+    - stretch
   # - name: Fedora
   #   versions:
   #   - all
@@ -52,6 +52,7 @@ galaxy_info:
 
   galaxy_tags:
   - zerotier-one
+  - networking
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to
     # remove the '[]' above, if you add tags to this list.

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -1,0 +1,31 @@
+---
+- block:
+  - name: Get Zerotier NodeID
+    shell: zerotier-cli info | awk '{print $3}'
+    register: nodeid
+    changed_when: false
+
+  - name: Set NodeID as fact
+    set_fact:
+      zerotier_node_id: "{{ nodeid.stdout }}"
+
+  - name: Add and authorize members to network
+    uri:
+      url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ zerotier_node_id }}"
+      method: POST
+      headers:
+        Authorization: bearer {{ zerotier_accesstoken }}
+      body:
+        name: "{{ zerotier_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname) }}"
+        hidden: false
+        config:
+          authorized: "{{ zerotier_authorize_member }}"
+          ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
+      body_format: json
+    register: apiresult
+
+  when:
+  - zerotier_accesstoken is defined
+  - not ansible_check_mode
+  tags:
+  - configuration

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -17,6 +17,7 @@
         Authorization: bearer {{ zerotier_accesstoken }}
       body:
         name: "{{ zerotier_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname) }}"
+        description: "{{ zerotier_member_description | default() }}"
         hidden: false
         config:
           authorized: "{{ zerotier_authorize_member }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,41 +1,9 @@
 ---
 
-  # Redhat variants
-- block: # Add zerotier repo and it's gpg key
-  - name: Add zerotier gpg key
-    rpm_key:
-      state: present
-      key: https://download.zerotier.com/contact%40zerotier.com.gpg
-
-  - name: Add zerotier repo
-    yum_repository:
-      name: zerotier
-      description: ZeroTier, Inc. RPM Release Repository
-      baseurl: https://download.zerotier.com/redhat/el/$releasever
-      gpgcheck: yes
-      enabled: yes
-    register: zerotier_repo
+- include_tasks: install/{{ ansible_os_family }}.yml
   tags:
   - installation
   - repositories
-  when: ansible_os_family == "RedHat"
-
-  # Debian variants
-- block: # Add zerotier repo and it's gpg key if not already done.
-  - name: Check if zerotier is already installed
-    stat:
-      path: /etc/apt/sources.list.d/zerotier.list
-    register: zerotier_repo
-
-  - name: Install zerotier
-    shell: curl -s 'https://pgp.mit.edu/pks/lookup?op=get&search=0x1657198823E52A61' | gpg --import && \
-               if z=$(curl -s 'https://install.zerotier.com/' | gpg); then echo "$z" | sudo bash; fi
-    register: zerotier_repo
-    when: zerotier_repo.stat.exists == False
-  tags:
-  - installation
-  - repositories
-  when: ansible_os_family == "Debian"
 
 - block: #Install and enable zerotier-one
   - name: Install zerotier-one

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,12 +17,12 @@
       name: zerotier-one
       state: started
     when:
-    - zerotier_client|succeeded
+    - zerotier_client is succeeded
     notify:
     - enable zerotier-one
 
   when:
-  - zerotier_repo|succeeded
+  - zerotier_repo is succeeded
   - not ansible_check_mode
   tags:
   - installation

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,0 +1,9 @@
+- name: Add ZeroTier PGP key
+  apt_key:
+    url: "{{ zerotier_gpg_url }}"
+
+- name: Add ZeroTier APT repository
+  apt_repository:
+    repo: deb {{ zerotier_download_base_url }}/debian/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
+    filename: zerotier
+  register: zerotier_repo

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -1,0 +1,13 @@
+- name: Add ZeroTier gpg key
+  rpm_key:
+    state: present
+    key: "{{ zerotier_gpg_url }}"
+
+- name: Add ZeroTier repo
+  yum_repository:
+    name: zerotier
+    description: ZeroTier, Inc. RPM Release Repository
+    baseurl: https://download.zerotier.com/redhat/el/$releasever
+    gpgcheck: yes
+    enabled: yes
+  register: zerotier_repo

--- a/tasks/join_network.yml
+++ b/tasks/join_network.yml
@@ -1,34 +1,7 @@
 ---
-- block: # Join Zerotier network
-  - name: Get Zerotier NodeID
-    shell: zerotier-cli info | awk '{print $3}'
-    register: nodeid
-
-  - name: Set NodeID as fact
-    set_fact:
-      zerotier_node_id: "{{ nodeid.stdout }}"
-
-  - name: Add and authorize members to network
-    uri:
-      url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ zerotier_node_id }}"
-      method: POST
-      headers:
-        Authorization: bearer {{ zerotier_accesstoken }}
-      body:
-        name: "{{ inventory_hostname }}"
-        hidden: false
-        config:
-          authorized: true
-      body_format: json
-    register: apiresult
-
-  - name: Join Zerotier network
-    command: zerotier-cli join {{ zerotier_network_id }}
-    args:
-      creates: /var/lib/zerotier-one/networks.d/{{ zerotier_network_id }}.conf
-
-  when:
-  - zerotier_accesstoken is defined
-  - not ansible_check_mode
+- name: Join ZeroTier network
+  command: zerotier-cli join {{ zerotier_network_id }}
+  args:
+    creates: /var/lib/zerotier-one/networks.d/{{ zerotier_network_id }}.conf
   tags:
   - configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,10 @@
 # tasks file for ansible-role-zerotier
 - import_tasks: install.yml
 
-- name: Check for successfully joined networks
-  shell: zerotier-cli listnetworks | grep 'OK'| awk '{print $3}'
-  register: joinednetworks
-  check_mode: yes
-
-- include_tasks: join_network.yml
+- import_tasks: authorize_node.yml
   when:
-  - 'zerotier_network_id not in joinednetworks.stdout'
   - zerotier_accesstoken is defined
+
+- import_tasks: join_network.yml
+  when:
+  - zerotier_network_id is defined

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for ansible-role-zerotier
+zerotier_download_base_url: http://download.zerotier.com
+zerotier_gpg_url: https://download.zerotier.com/contact@zerotier.com.gpg


### PR DESCRIPTION
### Features added
- option to register member with it's short hostname
- option to assign IPv4 addresses to members
- option to set member description

### Improvements
- Joining networks and authorizing nodes are now separate, optional actions. They only run when their variables, respectively `zerotier_network_id` and `zerotier_accesstoken`,  are set.
- Modularized some of the tasks to use import_tasks (static) and include_tasks (dynamic). New directives of Ansible 2.4.
- Stopped using Ansible-provided Jinja tests as filters. (Deprecated as of Ansible 2.5 and will be removed in Ansible 2.9.)