### PR TITLE
Add Arch Linux support

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,7 +22,7 @@
     - enable zerotier-one
 
   when:
-  - zerotier_repo is succeeded
+  - zerotier_repo is not defined or zerotier_repo is succeeded
   - not ansible_check_mode
   tags:
   - installation

--- a/tasks/install/Archlinux.yml
+++ b/tasks/install/Archlinux.yml
@@ -1,0 +1,1 @@
+# zerotier-one is available in the official repositories


### PR DESCRIPTION
`zerotier-one` is available in the official repositories of Arch Linux.