### PR TITLE
Update package manager cache before install

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,7 @@
     package:
       name: zerotier-one
       state: present
+      update_cache: yes
     register: zerotier_client
 
   - name: Start zerotier-one service


### PR DESCRIPTION
As it currently stands, after the repo is added, apt-get update (or equivalent) is not performed, and zerotier-one install fails.