### PR TITLE
Make authentication delegation configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for ansible-role-zerotier
 zerotier_api_url: https://my.zerotier.com
+zerotier_api_delegate: localhost
 zerotier_apt_state: present
 zerotier_register_short_hostname: false
 zerotier_authorize_member: true

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -10,8 +10,7 @@
       zerotier_node_id: "{{ nodeid.stdout }}"
 
   - name: Authorize members to network
-    local_action:
-      module: uri
+    uri:
       url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ zerotier_node_id }}"
       method: POST
       headers:
@@ -21,12 +20,12 @@
         config:
           authorized: "{{ zerotier_authorize_member }}"
       body_format: json
-    register: auth_apiresult
-    become: false
+      register: auth_apiresult
+      become: false
+    delegate_to: "{{ zerotier_api_delegate }}"
 
   - name: Configure members in network
-    local_action:
-      module: uri
+    uri:
       url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ zerotier_node_id }}"
       method: POST
       headers:
@@ -37,8 +36,9 @@
         config:
           ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
       body_format: json
-    register: conf_apiresult
-    become: false
+      register: conf_apiresult
+      become: false
+    delegate_to: "{{ zerotier_api_delegate }}"
 
   when:
   - zerotier_accesstoken is defined


### PR DESCRIPTION
Before this commit the authentication task was runned as a local_action
so if the zerotier controller was on a different machine that the
ansible controller, the zerotier controller API had to bind to 0.0.0.0
instead of 127.0.0.1 with the security implication this burden this
imply (setup HTTPS, setup firewall and so on).
With this commit this behaviour is now configurable with zerotier_api_delegate
variable, by default that variable is set to localhost so it behave
exactly as before this commit, but if set the action is run on the
preferred machine, in my case the zerotier network controller is part of
the same playbook so I set
    zerotier_api_delegate: zerotierNetworkControllerMachineName
    zerotier_api_url: http://127.0.0.1:9993/
So I can benefit from this ansible role without the burden of setting up
global listening + HTTPS etc...