### PR TITLE
Add sudo for install and zerotier-cli commands

### DIFF
--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -4,6 +4,7 @@
     shell: zerotier-cli info | awk '{print $3}'
     register: nodeid
     changed_when: false
+    become: yes
 
   - name: Set NodeID as fact
     set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - import_tasks: install.yml
   when:
   - not skip_install|default(false)|bool
+  become: yes
 
 - import_tasks: authorize_node.yml
   when:
@@ -11,3 +12,4 @@
 - import_tasks: join_network.yml
   when:
   - zerotier_network_id is defined
+  become: yes


### PR DESCRIPTION
The role as of v1.1.0 or commit:89c5635 (master) didn't work for me on Ubuntu 18.04 Bionic, every apt and zerotier-cli step needed become: yes.

This PR adds become: yes to the main.yml where install and join_network tasklists get included as all of their tasks require sudo, and adds one use in authorize_node.yml because of one usage of the zerotier-cli.

Note: Your role is unlicensed. By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.