### PR TITLE
Update set_fact.sh to support multiple network

### DIFF
--- a/files/set_facts.sh
+++ b/files/set_facts.sh
@@ -6,7 +6,7 @@ NETWORKS=$(zerotier-cli listnetworks | tail -n+2)
 
 function file_content {
     if [ ! -z "$NETWORKS" ]; then
-        network_count=$(echo $NETWORKS |wc -l)
+        network_count=$(echo "$NETWORKS" |wc -l)
         counter=1
 
         echo "{"


### PR DESCRIPTION
Currently the role will fail to regather fact if there is more than 1 zerotier network configured

NETWORKS=$(zerotier-cli listnetworks | tail -n+2) will rightly contain the data with `\n`

But without the quotes echo will suppress the `\n` writing everything in one line.
Thus `wc -l` will return `1`, confusing the file_content function that will lead to an incorrect json being produced

How to reproduce?
Without the fix, try to setup a second zerotier network - You will see that the regather fact step will fail, leading to no authorization of the node (as it cannot get the right fact)
If you inspect `/etc/ansible/facts.d/zerotier.fact` you will see that the json is malformed, the first network will fulfill https://github.com/m4rcu5nl/ansible-role-zerotier/blob/c7aae63e166f1bf7dd2efc13e82352cf53b1d7a6/files/set_facts.sh#L21 while all the others will match https://github.com/m4rcu5nl/ansible-role-zerotier/blob/c7aae63e166f1bf7dd2efc13e82352cf53b1d7a6/files/set_facts.sh#L23