### PR TITLE
fix usage of register variable function

### DIFF
--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -11,7 +11,7 @@
         config:
           authorized: "{{ zerotier_authorize_member }}"
       body_format: json
-      register: auth_apiresult
+    register: auth_apiresult
     delegate_to: "{{ zerotier_api_delegate }}"
     when:
       - ansible_local.zerotier.networks[zerotier_network_id] is not defined or ansible_local.zerotier.networks[zerotier_network_id].status != 'OK'
@@ -28,7 +28,7 @@
         config:
           ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
       body_format: json
-      register: conf_apiresult
+    register: conf_apiresult
     delegate_to: "{{ zerotier_api_delegate }}"
 
   when:


### PR DESCRIPTION
Update to latest ansible version (2.9.0) on ubuntu 18.04 lead to the message `Unsupported parameters for (uri) module: register`.

This PR fixes this error.