### PR TITLE
Fixed wrong indentation

### DIFF
--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -11,7 +11,7 @@
         config:
           authorized: "{{ zerotier_authorize_member }}"
       body_format: json
-      register: auth_apiresult
+    register: auth_apiresult
     delegate_to: "{{ zerotier_api_delegate }}"
     when:
       - ansible_local.zerotier.networks[zerotier_network_id] is not defined or ansible_local.zerotier.networks[zerotier_network_id].status != 'OK'
@@ -28,7 +28,7 @@
         config:
           ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
       body_format: json
-      register: conf_apiresult
+    register: conf_apiresult
     delegate_to: "{{ zerotier_api_delegate }}"
 
   when:


### PR DESCRIPTION
Fixes this error:

```
TASK [ansible-role-zerotier : Authorize new members to network] **************************************************************************************************************************
fatal: [X.X.X.X -> localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (uri) module: register Supported parameters include: attributes, backup, body, body_format, client_cert, client_key, content, creates, delimiter, dest, directory_mode, follow, follow_redirects, force, force_basic_auth, group, headers, http_agent, method, mode, owner, regexp, remote_src, removes, return_content, selevel, serole, setype, seuser, src, status_code, timeout, unix_socket, unsafe_writes, url, url_password, url_username, use_proxy, validate_certs"}
```