### PR TITLE
Fix missing repository on Ubuntu 20.x

### DIFF
--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -12,16 +12,23 @@
   register: release_repo
 
 - block:
-  - name: Overwrite Ubuntu release repo name
+  - name: Overwrite Ubuntu release repo name for cosmic
     set_fact:
       zerotier_deb_release_repo: bionic
+    when: 
+     - ansible_facts['distribution_major_version'] == "18"
+
+  - name: Overwrite Ubuntu release repo name for focal
+    set_fact:
+      zerotier_deb_release_repo: bionic
+    when: 
+     - ansible_facts['distribution_major_version'] == "20"
 
   - name: Re-gather facts
     setup: ~
 
   when:
     - ansible_facts['distribution'] == "Ubuntu"
-    - ansible_facts['distribution_major_version'] == "18"
     - release_repo.status == 404
 
 - name: Add ZeroTier APT repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - import_tasks: authorize_node.yml
   when:
-  - zerotier_api_accesstoken | length > 0
+  - zerotier_api_accesstoken != ''
   - ansible_local['zerotier']['node_id'] is defined
 
 - import_tasks: join_network.yml


### PR DESCRIPTION
When installing on Ubuntu `20.x` the apt configuration fails as the repository is missing.

Zerotier still does not have a release for `focal`. I adapted the fix for `cosmic` to also check for `20.x` releases.