### PR TITLE
Keep existing IP assignments if none are provided

### DIFF
--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -27,7 +27,7 @@
         name: "{{ zerotier_member_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname) }}"
         description: "{{ zerotier_member_description | default() }}"
         config:
-          ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
+          ipAssignments: "{{ zerotier_member_ip_assignments | default() }}"
       body_format: json
     register: conf_apiresult
     delegate_to: "{{ zerotier_api_delegate }}"


### PR DESCRIPTION
Defaulting ipAssignments to [] will reset the IP assignments for the member each time the playbook runs if zerotier_member_ip_assignments is not set. If automatic IP assignment is enabled, ZeroTier will then automatically assign a new IP, but in my experience the new IP will not always be the same as the previous one. Omitting the ipAssignments list when we don't want to assign an IP manually seems to fix the issue.