### PR TITLE
Add role state management and uninstallation tasks for ZeroTier

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,23 @@ Example Inventory
     [dbservers:vars]
     zerotier_member_description='<AppName> db cluster node'
 ```
+
+Role State Management
+--------------------
+
+By default, this role installs and configures ZeroTier on the target hosts.  
+If you want to **remove** ZeroTier (leave the network, deauthorize the node, and uninstall the package), set the variable `state: absent` for the role in your playbook:
+
+```yaml
+- hosts: servers
+  roles:
+    - role: ansible-role-zerotier
+      state: absent
+```
+
+When `state: absent` is set, the role will:
+- Leave the ZeroTier network (if joined)
+- Deauthorize and remove the node from ZeroTier Central (if API access is configured)
+- Uninstall the `zerotier-one` package and remove related files
+
+If `state` is not set or set to `present`, the role will perform installation and configuration as described above.

--- a/tasks/deauthorize_node.yml
+++ b/tasks/deauthorize_node.yml
@@ -1,0 +1,23 @@
+---
+- block:
+    - name: Deauthorize (remove) node from ZeroTier Central via API
+      uri:
+        url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ ansible_local['zerotier']['node_id'] }}"
+        method: DELETE
+        headers:
+          Authorization: bearer {{ zerotier_api_accesstoken }}
+        status_code: [200, 204]
+        force_basic_auth: yes
+      register: deauth_apiresult
+      delegate_to: "{{ zerotier_api_delegate }}"
+      when:
+        - zerotier_api_accesstoken is defined
+        - zerotier_network_id is defined
+        - ansible_local['zerotier']['node_id'] is defined
+        - ansible_local['zerotier']['node_id'] | length > 0
+
+  when:
+    - not ansible_check_mode
+  tags:
+    - configuration
+  become: false

--- a/tasks/leave_network.yml
+++ b/tasks/leave_network.yml
@@ -1,0 +1,13 @@
+---
+- name: Leave ZeroTier network
+  command: zerotier-cli leave {{ zerotier_network_id }}
+  args:
+    removes: /var/lib/zerotier-one/networks.d/{{ zerotier_network_id }}.conf
+  tags:
+    - configuration
+  when:
+    - zerotier_network_id is defined
+    - ansible_local['zerotier']['node_id'] is defined
+    - ansible_local['zerotier']['networks'][zerotier_network_id] is defined
+    - ansible_local['zerotier']['networks'][zerotier_network_id]['status'] == 'OK'
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,42 @@
 ---
 # tasks file for ansible-role-zerotier
-- import_tasks: install.yml
-  when:
-  - not skip_install | default(false) | bool
 
 - block:
-  - name: Update ansible_local facts
-    script: set_facts.sh
+    - import_tasks: leave_network.yml
+      when:
+        - zerotier_network_id is defined
+        - ansible_local['zerotier']['networks'][zerotier_network_id] is defined
+        - ansible_local['zerotier']['networks'][zerotier_network_id]['status'] == 'OK'
 
-  - name: Re-gather ansible_local facts
-    setup: filter=ansible_local
+    - import_tasks: deauthorize_node.yml
+      when:
+        - zerotier_api_accesstoken | length > 0
+        - ansible_local['zerotier']['node_id'] is defined
 
+    - import_tasks: uninstall.yml
 
-- import_tasks: authorize_node.yml
   when:
-  - zerotier_api_accesstoken | length > 0
-  - ansible_local['zerotier']['node_id'] is defined
+    - state | default('present') == 'absent'
 
-- import_tasks: join_network.yml
+- block:
+    - import_tasks: install.yml
+      when:
+        - not skip_install | default(false) | bool
+
+    - name: Update ansible_local facts
+      script: set_facts.sh
+
+    - name: Re-gather ansible_local facts
+      setup: filter=ansible_local
+
+    - import_tasks: authorize_node.yml
+      when:
+        - zerotier_api_accesstoken | length > 0
+        - ansible_local['zerotier']['node_id'] is defined
+
+    - import_tasks: join_network.yml
+      when:
+        - zerotier_network_id is defined
+
   when:
-  - zerotier_network_id is defined
+    - state | default('present') != 'absent'

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,0 +1,35 @@
+---
+- block: # Uninstall and disable zerotier-one
+    - name: Stop zerotier-one service
+      service:
+        name: zerotier-one
+        state: stopped
+      ignore_errors: true
+
+    - name: Disable zerotier-one service
+      service:
+        name: zerotier-one
+        enabled: false
+      ignore_errors: true
+
+    - name: Uninstall zerotier-one package
+      package:
+        name: zerotier-one
+        state: absent
+      register: zerotier_uninstalled
+
+    - name: Remove ZeroTier data and config directories
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /var/lib/zerotier-one
+        - /etc/zerotier-one
+        - /var/log/zerotier-one.log
+      ignore_errors: true
+
+  when:
+    - not ansible_check_mode
+  tags:
+    - uninstallation
+    - packages


### PR DESCRIPTION
**Pull Request: Add Uninstallation and Deregistration Support via `state: absent`**

### Summary

This PR adds full support for clean uninstallation and deregistration of ZeroTier nodes using the standard Ansible `state` variable.  
By default, the role continues to install and configure ZeroTier as before.  
If `state: absent` is set, the role will:

- Leave the ZeroTier network (if joined)
- Deauthorize and remove the node from ZeroTier Central via API (if API access is configured)
- Uninstall the `zerotier-one` package and remove all related files

### Details

- Refactored `tasks/main.yml` to support both installation (`state: present` or unset) and uninstallation (`state: absent`) flows.
- Added tasks for leaving the network, deauthorizing the node, and uninstalling/removing files.
- Updated `README.md` with clear instructions and examples for using `state: absent` to remove ZeroTier from hosts.

### Backward Compatibility

- No breaking changes: if `state` is not set, the role behaves as before (installation/configuration).
- Users can now manage the full ZeroTier lifecycle with a single role and a standard Ansible interface.
